### PR TITLE
Project A - Add terraform/monitoring/ Directory

### DIFF
--- a/project-a-zero-trust-landing-zone/terraform/monitoring/nonprod/README.md
+++ b/project-a-zero-trust-landing-zone/terraform/monitoring/nonprod/README.md
@@ -1,0 +1,14 @@
+# Monitoring – Non-Production
+
+This directory is reserved for the **Non-Production (NPR)** Azure Landing Zone monitoring environment.
+
+## Status
+
+- No monitoring resources are currently deployed in NPR
+- When NPR is enabled, it will mirror the structure and configuration of `/monitoring/prod/` for consistency and safe testing of changes.
+
+## Next Steps
+
+- When ready, copy or adapt the Terraform code from `/monitoring/prod/` to deploy an NPR Log Analytics Workspace and related resources.
+
+---

--- a/project-a-zero-trust-landing-zone/terraform/monitoring/prod/README.md
+++ b/project-a-zero-trust-landing-zone/terraform/monitoring/prod/README.md
@@ -1,0 +1,20 @@
+# Monitoring – Production
+
+This directory contains the Terraform code for deploying monitoring resources in the **Production** Azure Landing Zone environment.
+
+## What’s Deployed
+
+- **Log Analytics Workspace** (`alz-law-prod`)
+  - Centralized workspace for diagnostics/logs from networking, identity, governance, and other domains.
+- (Optional) Additional monitoring solutions (e.g., Azure Sentinel) can be added here.
+
+## Usage
+
+- Deploy this code before referencing the workspace in other domains (e.g., networking, identity).
+- Other domains should use a data block to reference the workspace by name and resource group.
+
+## Zero Trust & SC-100 Alignment
+
+Centralized monitoring and diagnostics are critical for Zero Trust visibility, threat detection, and compliance, supporting your SC-100 learning objectives.
+
+---


### PR DESCRIPTION
Add a `/monitoring` directory to the Terraform codebase to support a separate, centralised monitoring domain for the ALZ. 

Include a README file in each sub-directory (`/prod` and `/nonprod`)