### PR TITLE
Project A - networking/prod - Update Pattern for Resource Names and Tags

### DIFF
--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/bastion-host.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/bastion-host.tf
@@ -5,7 +5,7 @@ module "bastion" {
 
   # Required inputs.
   location            = azurerm_resource_group.networking.location
-  name                = "hub-bastion"
+  name                = "hub-bastion-${var.environment}" # Consider changing order of naming elements.
   resource_group_name = azurerm_resource_group.networking.name
 
   # Optional inputs.
@@ -15,5 +15,5 @@ module "bastion" {
     public_ip_address_id = var.bastion_public_ip_address_id
   }
 
-  tags                = var.tags
+  tags                = local.tags
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/firewall.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/firewall.tf
@@ -8,7 +8,7 @@ module "firewall" {
   firewall_sku_name   = var.firewall_sku_name # Default is "AZFW_VNet".
   firewall_sku_tier   = var.firewall_sku_tier # Default is "Standard".
   location            = azurerm_resource_group.networking.location
-  name                = "hub-firewall"
+  name                = "hub-firewall-${var.environment}" # Consider changing order of naming elements.
   resource_group_name = azurerm_resource_group.networking.name
 
   # Optional inputs.
@@ -18,5 +18,5 @@ module "firewall" {
     public_ip_address_id = var.firewall_public_ip_address_id
   }
 
-  tags = var.tags
+  tags = local.tags
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/locals.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/locals.tf
@@ -9,6 +9,7 @@ locals {
     "AzureBastionSubnet",
     "shared-services"
   ]
+
   spoke_subnet_prefixes = [
     "10.1.1.0/24",   # App Subnet
     "10.1.2.0/24"    # Data Subnet
@@ -17,4 +18,10 @@ locals {
     "app",
     "data"
   ]
+
+  tags = {
+    domain      = var.domain
+    environment = var.environment
+    owner       = var.owner
+  }
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/network-security-group.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/network-security-group.tf
@@ -6,7 +6,7 @@ module "app_nsg" {
 
   # Required inputs.  
   location            = var.location
-  name                = "app-nsg"
+  name                = "app-nsg-${var.environment}" # Consider changing order of naming elements.
   resource_group_name = azurerm_resource_group.networking.name
 
   # Optional inputs.  
@@ -26,7 +26,7 @@ module "app_nsg" {
     # Add more rules as needed
   ]
 
-  tags = var.tags
+  tags = local.tags
 }
 
 module "data_nsg" {
@@ -34,7 +34,7 @@ module "data_nsg" {
   version = "~> 0.5.0"
 
   location            = var.location
-  name                = "data-nsg"
+  name                = "data-nsg" # Consider changing order of naming elements.
   resource_group_name = azurerm_resource_group.networking.name
 
   security_rules = [
@@ -53,7 +53,7 @@ module "data_nsg" {
     # Add more rules as needed
   ]
 
-  tags = var.tags
+  tags = local.tags
 }
 
 # Associate each NSG with the relevant subnet.

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/private-dns-zone-virtual-network-link.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/private-dns-zone-virtual-network-link.tf
@@ -2,21 +2,21 @@
 # For this reason, we use the native 'azurerm_private_dns_zone_virtual_network_link' resource block.
 # This approach is recommended and future-proof until an AVM module is released.
 resource "azurerm_private_dns_zone_virtual_network_link" "hub_link" {
-  name                  = "hub-vnet-link"
+  name                  = "hub-vnet-link" # Consider changing order of naming elements.
   resource_group_name   = azurerm_resource_group.networking.name
   private_dns_zone_name = module.private_dns.name
   virtual_network_id    = module.hub_vnet.resource.id
   registration_enabled  = false
   
-  tags                  = var.tags
+  tags                  = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "spoke_link" {
-  name                  = "spoke-vnet-link"
+  name                  = "spoke-vnet-link" # Consider changing order of naming elements.
   resource_group_name   = azurerm_resource_group.networking.name
   private_dns_zone_name = module.private_dns.name
   virtual_network_id    = module.spoke_vnet.resource.id
   registration_enabled  = false
 
-  tags                  = var.tags
+  tags                  = local.tags
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/private-dns-zone.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/private-dns-zone.tf
@@ -8,5 +8,5 @@ module "private_dns" {
 
   # Optional inputs TBC.
 
-  tags                = var.tags
+  tags                = local.tags
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/resource-group.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/resource-group.tf
@@ -1,5 +1,6 @@
 resource "azurerm_resource_group" "networking" {
-  name     = var.resource_group_name
+  name     = "alz-${var.domain}-rg-${var.location}" # Consider changing order of naming elements.
   location = var.location
-  tags     = var.tags
+
+  tags     = local.tags
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/variables.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/variables.tf
@@ -1,6 +1,24 @@
+variable "domain" {
+  description = "The functional domain for this deployment (e.g. networking, monitoring, identity, governance)  Used for tagging and resource organisation."
+  type        = string
+  default     = "networking"
+}
+
+variable "environment" {
+  description = "The logical environment for this deployment (e.g. prod, nonprod, dev, test)  Used for naming, tagging, and environment-specific configuration."
+  type        = string
+  default     = "prod"
+}
+
 variable "location" {
   description = "Azure region for resources."
   default     = "East US"
+}
+
+variable "owner" {
+  description = "The owner of the Azure resources."
+  type        = string
+  default     = "sking-dev"
 }
 
 variable "resource_group_name" {
@@ -14,13 +32,4 @@ variable "hub_vnet_address_space" {
 
 variable "spoke_vnet_address_space" {
   default = "10.1.0.0/16"
-}
-
-variable "tags" {
-  description = "Tags to apply to resources"
-  type        = map(string)
-  default     = {
-    environment = "prod"
-    owner       = "sking-dev"
-  }
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/virtual-network.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/virtual-network.tf
@@ -8,20 +8,24 @@ module "hub_vnet" {
   resource_group_name = azurerm_resource_group.networking.name
 
   # Optional inputs.
-  name                = "hub-vnet"
+  name                = "hub-vnet-${var.environment}" # Consider changing order of naming elements.
   subnets             = local.hub_subnet_prefixes
 
-  tags                = var.tags
+  tags                = local.tags
 }
 
 module "spoke_vnet" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "~> 0.9.0"
 
-  name                = "spoke1-vnet"
-  resource_group_name = azurerm_resource_group.networking.name
-  location            = azurerm_resource_group.networking.location
+  # Required inputs.
   address_space       = [var.spoke_vnet_address_space]
+  location            = azurerm_resource_group.networking.location
+  resource_group_name = azurerm_resource_group.networking.name
+
+  # Optional inputs.
+  name                = "spoke1-vnet-${var.environment}" # Consider changing order of naming elements.
   subnets             = local.spoke_subnet_prefixes
-  tags                = var.tags
+
+  tags                = local.tags
 }


### PR DESCRIPTION
Update the resource naming and tags pattern used for existing networking/prod resources.

NOTE: This constitutes the adoption of / standardisation on the newer. desired variable-driven pattern can be found in `monitoring/prod`.