### PR TITLE
Project A - Add Diagnostic Settings to Existing Networking Resources

### DIFF
--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/bastion-host.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/bastion-host.tf
@@ -15,5 +15,14 @@ module "bastion" {
     public_ip_address_id = var.bastion_public_ip_address_id
   }
 
+  diagnostic_settings = {
+    bastion_diag = {
+      workspace_resource_id          = data.azurerm_log_analytics_workspace.monitoring.id
+      log_analytics_destination_type = "Dedicated"
+      log_categories                 = local.log_categories_bastion
+      metric_categories              = ["AllMetrics"]
+    }
+  }
+
   tags                = local.tags
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/data.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/data.tf
@@ -1,0 +1,5 @@
+# Data source to enable retrieval of attributes from existing Log Analytics workspace deployed by the /monitoring domain.
+data "azurerm_log_analytics_workspace" "monitoring" {
+  name                = "law-alz-${var.environment}"
+  resource_group_name = "rg-${var.location}-alz-monitoring-${var.environment}"
+}

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/firewall.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/firewall.tf
@@ -18,5 +18,14 @@ module "firewall" {
     public_ip_address_id = var.firewall_public_ip_address_id
   }
 
+  diagnostic_settings = {
+    bastion_diag = {
+      workspace_resource_id          = data.azurerm_log_analytics_workspace.monitoring.id
+      log_analytics_destination_type = "Dedicated"
+      log_categories                 = local.log_categories_firewall
+      metric_categories              = ["AllMetrics"]
+    }
+  }
+
   tags = local.tags
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/locals.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/locals.tf
@@ -10,6 +10,27 @@ locals {
     "shared-services"
   ]
 
+  # Bastion host log catagories.
+  log_categories_bastion = [
+    "BastionAuditLogs"
+  ]
+  # Azure Firewall log categories.
+  log_categories_firewall = [
+    "AzureFirewallApplicationRule",
+    "AzureFirewallNetworkRule",
+    "AzureFirewallDnsProxy",
+    "AzureFirewallThreatIntel"
+  ]
+  # Network Security Group (NSG) log categories.
+  log_categories_nsg = [
+    "NetworkSecurityGroupEvent",
+    "NetworkSecurityGroupRuleCounter"
+  ]
+  # Virtual Network log categories.
+  log_categories_vnet = [
+    "VMProtectionAlerts"
+  ]
+
   spoke_subnet_prefixes = [
     "10.1.1.0/24",   # App Subnet
     "10.1.2.0/24"    # Data Subnet

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/network-security-group.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/network-security-group.tf
@@ -53,6 +53,15 @@ module "data_nsg" {
     # Add more rules as needed
   ]
 
+  diagnostic_settings = {
+    bastion_diag = {
+      workspace_resource_id          = data.azurerm_log_analytics_workspace.monitoring.id
+      log_analytics_destination_type = "Dedicated"
+      log_categories                 = local.log_categories_nsg
+      metric_categories              = ["AllMetrics"]
+    }
+  }
+
   tags = local.tags
 }
 

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/virtual-network.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/virtual-network.tf
@@ -27,5 +27,14 @@ module "spoke_vnet" {
   name                = "spoke1-vnet-${var.environment}" # Consider changing order of naming elements.
   subnets             = local.spoke_subnet_prefixes
 
+  diagnostic_settings = {
+    bastion_diag = {
+      workspace_resource_id          = data.azurerm_log_analytics_workspace.monitoring.id
+      log_analytics_destination_type = "Dedicated"
+      log_categories                 = local.log_categories_vnet
+      metric_categories              = ["AllMetrics"]
+    }
+  }
+
   tags                = local.tags
 }


### PR DESCRIPTION
Update all existing `/networking/prod` resources (where supported) to use the `diagnostic_settings` input to send each resource's logs and metrics to the centralised Log Analytics workspace (deployed by the `monitoring/` domain)