### PR TITLE
Project A - Standardise Resource Naming Across ALZ Domains

### DIFF
--- a/project-a-zero-trust-landing-zone/terraform/monitoring/prod/locals.tf
+++ b/project-a-zero-trust-landing-zone/terraform/monitoring/prod/locals.tf
@@ -1,8 +1,10 @@
 locals {
+  # Generate short version of Azure location to use in resource naming.
+  region_short = var.location == "uksouth" ? "uks" : "ukw"
+  
   tags = {
     domain      = var.domain
     environment = var.environment
     owner       = var.owner
   }
 }
-  

--- a/project-a-zero-trust-landing-zone/terraform/monitoring/prod/resource-group.tf
+++ b/project-a-zero-trust-landing-zone/terraform/monitoring/prod/resource-group.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "monitoring" {
-  name     = "alz-${var.domain}-rg-${var.location}" # Consider changing order of naming elements.
+  name     = "rg-${local.region_short}-alz-${var.domain}-${var.environment}"
   location = var.location
   
   tags = local.tags

--- a/project-a-zero-trust-landing-zone/terraform/monitoring/prod/variables.tf
+++ b/project-a-zero-trust-landing-zone/terraform/monitoring/prod/variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "location" {
   description = "Azure region for resources."
-  default     = "East US"
+  default     = "uksouth"
 }
 
 variable "owner" {

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/README.md
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/README.md
@@ -105,6 +105,56 @@ prod/
 
 ---
 
+## Resource Naming Conventions
+
+To ensure clarity, consistency, and scalability across the Azure Landing Zone, all resource groups and resources follow the naming patterns below.
+
+### Resource Groups
+
+**Pattern:**  
+`rg-<location>-<project>-<domain>-<environment>`
+
+**Example:**  
+`rg-uks-alz-networking-prod`
+
+- `location`: Azure region short name (e.g., `uks` for UK South, `eus` for East US)
+- `project`: Project or workload name (e.g., `alz`)
+- `domain`: Functional domain (e.g., `networking`, `monitoring`, `identity`)
+- `environment`: Environment (e.g., `prod`, `nonprod`, `dev`, `test`)
+
+### Networking Resources
+
+**Pattern:**  
+`<type>-<project>-<hub|spokeX>-<role>-<environment>`
+
+**Examples:**
+
+- Hub VNet: `vnet-alz-hub-prod`
+- Spoke 1 VNet: `vnet-alz-spoke1-prod`
+- Hub Bastion: `bastion-alz-hub-prod`
+- Hub Firewall: `fw-alz-hub-prod`
+- Spoke 1 NSG (App Subnet): `nsg-alz-spoke1-app-prod`
+- Spoke 1 NSG (Data Subnet): `nsg-alz-spoke1-data-prod`
+- Spoke 1 App Subnet: `subnet-app-alz-spoke1-prod`
+- Hub Shared Services Subnet: `subnet-shared-alz-hub-prod`
+
+- `type`: Resource type abbreviation (e.g., `vnet`, `nsg`, `bastion`, `fw`, `subnet-app`)
+- `project`: Project or workload name (e.g., `alz`)
+- `hub|spokeX`: Logical network segment (`hub`, `spoke1`, `spoke2`, etc.)
+- `role`: Subnet or NSG role (e.g., `app`, `data`, `shared`, `mgmt`)
+- `environment`: Environment (`prod`, `nonprod`)
+
+> **Note:** The domain is included in the resource group name but not typically in the individual resource name, unless needed for disambiguation.  The `hub`/`spokeX` distinction is always included for networking resources to support clarity and scalability.  
+The `role` field is especially important for NSGs and subnets to avoid ambiguity and support clear mapping between resources.
+
+### Rationale
+
+- **Location** and **environment** are always included in resource group names for clarity and to prevent ambiguity in multi-region or multi-environment deployments.
+- **Project/workload**, **type**, and **logical segment** (`hub`/`spokeX`) ensure resources are easily identifiable, grouped logically, and scalable as the environment grows.
+- This pattern aligns with [Microsoft’s CAF naming and tagging best practices](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging) and supports enterprise-scale ALZ and Zero Trust architectures.
+
+---
+
 ## Getting Started
 
 - Review and update variables in `variables.tf` as needed for your environment

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/bastion-host.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/bastion-host.tf
@@ -1,11 +1,11 @@
-# NOTE: Create variables plus any additional optional inputs to make this code operational.
+# TODO: Create variables plus any additional optional inputs to make this code operational.
 module "bastion" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
   version = "~> 0.8.0"
 
   # Required inputs.
   location            = azurerm_resource_group.networking.location
-  name                = "hub-bastion-${var.environment}" # Consider changing order of naming elements.
+  name                = "bastion-alz-hub-${var.environment}"
   resource_group_name = azurerm_resource_group.networking.name
 
   # Optional inputs.
@@ -24,5 +24,5 @@ module "bastion" {
     }
   }
 
-  tags                = local.tags
+  tags = local.tags
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/firewall.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/firewall.tf
@@ -1,4 +1,4 @@
-# NOTE: Create variables plus any additional optional inputs to make this code operational.
+# TODO: Create variables plus any additional optional inputs to make this code operational.
 
 module "firewall" {
   source  = "Azure/avm-res-network-azurefirewall/azurerm"
@@ -8,7 +8,7 @@ module "firewall" {
   firewall_sku_name   = var.firewall_sku_name # Default is "AZFW_VNet".
   firewall_sku_tier   = var.firewall_sku_tier # Default is "Standard".
   location            = azurerm_resource_group.networking.location
-  name                = "hub-firewall-${var.environment}" # Consider changing order of naming elements.
+  name                = "fw-alz-hub-${var.environment}"
   resource_group_name = azurerm_resource_group.networking.name
 
   # Optional inputs.
@@ -19,7 +19,7 @@ module "firewall" {
   }
 
   diagnostic_settings = {
-    bastion_diag = {
+    firewall_diag = {
       workspace_resource_id          = data.azurerm_log_analytics_workspace.monitoring.id
       log_analytics_destination_type = "Dedicated"
       log_categories                 = local.log_categories_firewall

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/locals.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/locals.tf
@@ -31,11 +31,14 @@ locals {
     "VMProtectionAlerts"
   ]
 
-  spoke_subnet_prefixes = [
+  # Generate short version of Azure location to use in resource naming.
+  region_short = var.location == "uksouth" ? "uks" : "ukw"
+
+  spoke1_subnet_prefixes = [
     "10.1.1.0/24",   # App Subnet
     "10.1.2.0/24"    # Data Subnet
   ]
-  spoke_subnet_names = [
+  spoke1_subnet_names = [
     "app",
     "data"
   ]

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/network-security-group.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/network-security-group.tf
@@ -1,12 +1,12 @@
 # NOTE: As of July 2025, the Azure Verified Module (AVM) for Network Security Groups is available and recommended.
 # We use the AVM module for NSG creation, and the native resource block for subnet association.
-module "app_nsg" {
+module "app_nsg_spoke1" {
   source  = "Azure/avm-res-network-networksecuritygroup/azurerm"
   version = "~> 0.5.0"
 
   # Required inputs.  
   location            = var.location
-  name                = "app-nsg-${var.environment}" # Consider changing order of naming elements.
+  name                = "nsg-alz-spoke1-app-${var.environment}"
   resource_group_name = azurerm_resource_group.networking.name
 
   # Optional inputs.  
@@ -23,18 +23,27 @@ module "app_nsg" {
       destination_address_prefix = "*"
       description                = "Allow inbound HTTPS"
     },
-    # Add more rules as needed
+    # Add more rules as needed.
   ]
+
+  diagnostic_settings = {
+    nsg_diag = {
+      workspace_resource_id          = data.azurerm_log_analytics_workspace.monitoring.id
+      log_analytics_destination_type = "Dedicated"
+      log_categories                 = local.log_categories_nsg
+      metric_categories              = ["AllMetrics"]
+    }
+  }
 
   tags = local.tags
 }
 
-module "data_nsg" {
+module "data_nsg_spoke2" {
   source  = "Azure/avm-res-network-networksecuritygroup/azurerm"
   version = "~> 0.5.0"
 
   location            = var.location
-  name                = "data-nsg" # Consider changing order of naming elements.
+  name                = "nsg-alz-spoke1-data-${var.environment}"
   resource_group_name = azurerm_resource_group.networking.name
 
   security_rules = [
@@ -50,11 +59,11 @@ module "data_nsg" {
       destination_address_prefix = "*"
       description                = "Allow inbound SQL"
     },
-    # Add more rules as needed
+    # Add more rules as needed.
   ]
 
   diagnostic_settings = {
-    bastion_diag = {
+    nsg_diag = {
       workspace_resource_id          = data.azurerm_log_analytics_workspace.monitoring.id
       log_analytics_destination_type = "Dedicated"
       log_categories                 = local.log_categories_nsg
@@ -66,12 +75,12 @@ module "data_nsg" {
 }
 
 # Associate each NSG with the relevant subnet.
-resource "azurerm_subnet_network_security_group_association" "app" {
+resource "azurerm_subnet_network_security_group_association" "app_spoke1" {
   subnet_id                 = module.spoke_vnet.subnets["app"].resource_id
   network_security_group_id = module.app_nsg.resource.id
 }
 
-resource "azurerm_subnet_network_security_group_association" "data" {
+resource "azurerm_subnet_network_security_group_association" "data_spoke1" {
   subnet_id                 = module.spoke_vnet.subnets["data"].resource_id
   network_security_group_id = module.data_nsg.resource.id
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/private-dns-zone-virtual-network-link.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/private-dns-zone-virtual-network-link.tf
@@ -2,7 +2,7 @@
 # For this reason, we use the native 'azurerm_private_dns_zone_virtual_network_link' resource block.
 # This approach is recommended and future-proof until an AVM module is released.
 resource "azurerm_private_dns_zone_virtual_network_link" "hub_link" {
-  name                  = "hub-vnet-link" # Consider changing order of naming elements.
+  name                  = "hub-vnet-link"
   resource_group_name   = azurerm_resource_group.networking.name
   private_dns_zone_name = module.private_dns.name
   virtual_network_id    = module.hub_vnet.resource.id
@@ -11,8 +11,8 @@ resource "azurerm_private_dns_zone_virtual_network_link" "hub_link" {
   tags                  = local.tags
 }
 
-resource "azurerm_private_dns_zone_virtual_network_link" "spoke_link" {
-  name                  = "spoke-vnet-link" # Consider changing order of naming elements.
+resource "azurerm_private_dns_zone_virtual_network_link" "spoke1_link" {
+  name                  = "spoke1-vnet-link"
   resource_group_name   = azurerm_resource_group.networking.name
   private_dns_zone_name = module.private_dns.name
   virtual_network_id    = module.spoke_vnet.resource.id

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/resource-group.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/resource-group.tf
@@ -1,6 +1,6 @@
 resource "azurerm_resource_group" "networking" {
-  name     = "alz-${var.domain}-rg-${var.location}" # Consider changing order of naming elements.
+  name     = "rg-${local.region_short}-alz-${var.domain}-${var.environment}"
   location = var.location
 
-  tags     = local.tags
+  tags = local.tags
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/variables.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/variables.tf
@@ -30,6 +30,6 @@ variable "hub_vnet_address_space" {
   default = "10.0.0.0/16"
 }
 
-variable "spoke_vnet_address_space" {
+variable "spoke1_vnet_address_space" {
   default = "10.1.0.0/16"
 }

--- a/project-a-zero-trust-landing-zone/terraform/networking/prod/virtual-network.tf
+++ b/project-a-zero-trust-landing-zone/terraform/networking/prod/virtual-network.tf
@@ -8,24 +8,24 @@ module "hub_vnet" {
   resource_group_name = azurerm_resource_group.networking.name
 
   # Optional inputs.
-  name                = "hub-vnet-${var.environment}" # Consider changing order of naming elements.
+  name                = "vnet-alz-hub-${var.environment}"
   subnets             = local.hub_subnet_prefixes
 
-  tags                = local.tags
+  tags = local.tags
 }
 
-module "spoke_vnet" {
+module "spoke1_vnet" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "~> 0.9.0"
 
   # Required inputs.
-  address_space       = [var.spoke_vnet_address_space]
+  address_space       = [var.spoke1_vnet_address_space]
   location            = azurerm_resource_group.networking.location
   resource_group_name = azurerm_resource_group.networking.name
 
   # Optional inputs.
-  name                = "spoke1-vnet-${var.environment}" # Consider changing order of naming elements.
-  subnets             = local.spoke_subnet_prefixes
+  name                = "vnet-alz-spoke1-${var.environment}"
+  subnets             = local.spoke1_subnet_prefixes
 
   diagnostic_settings = {
     bastion_diag = {
@@ -36,5 +36,5 @@ module "spoke_vnet" {
     }
   }
 
-  tags                = local.tags
+  tags = local.tags
 }


### PR DESCRIPTION
**What?**

Adopt a consistent naming convention for all Azure resource groups and resources in both the `/monitoring` and `/networking` domains.

Resource Group Pattern:

`rg-<location>-<project>-<domain>-<environment>`

Example: `rg-uks-alz-monitoring-prod`

Resource Pattern:

`<type>-<project>-<hub|spokeX>-<role>-<environment>`

Note: `<role>` to be used to add clarity where necessary e.g. in NSG and subnet names

Examples: 

- `vnet-alz-spoke1-prod` 
  - Note: `<role>` is not required for this resource
- `nsg-alz-spoke1-app-prod`

**Why?**

To ensure clarity, scalability, and alignment with Azure CAF and enterprise best practices.

**How?**

- Update all resource group and resource names to follow the new convention
- Refactor any variable or locals blocks as needed
- Update `networking/prod` README to reflect the new naming pattern