### PR TITLE
Project A - Add Conditional Access Policies

### DIFF
--- a/project-a-zero-trust-landing-zone/terraform/identity/nonprod/README.md
+++ b/project-a-zero-trust-landing-zone/terraform/identity/nonprod/README.md
@@ -1,0 +1,15 @@
+# Identity Domain – Non-Production
+
+This directory is reserved for the **Non-Production (NPR)** Azure Landing Zone (ALZ) identity environment.
+
+## Status
+
+- No Conditional Access policies or identity resources are currently deployed in NPR
+- When NPR is enabled, it will mirror the structure and configuration of `/identity/prod/` for consistency and safe testing of changes before promotion to production
+
+## Next Steps
+
+- When ready, copy or adapt the Terraform code from `/identity/prod/` to deploy Conditional Access policies and other identity resources for NPR
+- Update any variable values (e.g. environment, excluded users) as needed to reflect non-production context
+
+---

--- a/project-a-zero-trust-landing-zone/terraform/identity/prod/README.md
+++ b/project-a-zero-trust-landing-zone/terraform/identity/prod/README.md
@@ -1,0 +1,83 @@
+# Identity Domain – Production
+
+This directory contains the Terraform code for managing **Conditional Access (CA) policies** in the Production Azure Landing Zone (ALZ) environment. This supports a Zero Trust security posture and directly aligns with SC-100 learning objectives.
+
+---
+
+## Purpose
+
+- Enforce identity perimeter controls as part of a Zero Trust ALZ
+- Manage Conditional Access (CA) policies as code for auditability, repeatability, and compliance
+- Demonstrate best practices for enterprise-scale identity governance
+
+---
+
+## What’s Implemented
+
+- **Three “must have” Conditional Access policies:**
+  1. **Require MFA for Admin Roles**
+  2. **Block Legacy Authentication**
+  3. **Require MFA for All Users**
+- Policies are implemented using the [AzureAD Terraform provider](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/conditional_access_policy)
+
+---
+
+## Prerequisites
+
+- **Terraform ≥ 1.6**
+- **AzureAD provider** configured (see `provider.tf`)
+- **Permissions:**  
+  - Executing user or Service Principal must have the **Conditional Access Administrator** (preferred) or **Global Administrator** role in Microsoft Entra ID (Azure AD).
+  - Contributor/Owner roles at the ARM/subscription level are **not sufficient**.
+- **Azure AD Premium P1 or P2 license** (required for Conditional Access)
+- **Remote state backend** (see `backend.tf`) must exist before running `terraform init`
+
+> **Note:** Deploying Conditional Access policies requires Azure AD Premium P1 or P2 licenses in your tenant.  
+> If you are using a personal or free Azure tenant without these licenses, you may not be able to test or enforce CA policies.  
+> For hands-on testing, consider using the [Microsoft 365 Developer Program](https://developer.microsoft.com/en-us/microsoft-365/dev-program) to obtain a free developer tenant with P1/P2 features.  This is free of charge at the time of writing.
+
+---
+
+## Key Files
+
+- `main.tf` – Conditional Access policy resource definitions
+- `provider.tf` – AzureAD provider configuration
+- `backend.tf` – Remote state backend configuration
+
+---
+
+## Example: Require MFA for Admin Roles
+
+```hcl
+resource "azuread_conditional_access_policy" "require_mfa_admins" {
+  display_name = "Require MFA for Admin Roles"
+  state        = "enabled"
+
+  conditions {
+    users {
+      included_roles = [
+        "62e90394-69f5-4237-9190-012177145e10" # Global Administrator
+      ]
+    }
+    applications {
+      included_applications = ["All"]
+    }
+    client_app_types = ["all"]
+  }
+
+  grant_controls {
+    operator = "or"
+    built_in_controls = ["mfa"]
+  }
+}
+```
+
+---
+
+## Next Steps
+
+- Add additional Conditional Access policies as required by your Zero Trust strategy
+- Document policy rationale and test results in this README
+- Integrate CA policy management with your broader ALZ deployment pipeline
+
+---

--- a/project-a-zero-trust-landing-zone/terraform/identity/prod/backend.tf
+++ b/project-a-zero-trust-landing-zone/terraform/identity/prod/backend.tf
@@ -1,0 +1,12 @@
+# NOTE: The remote state Storage Account, blob container, and (empty) blob (key) must exist
+# before running 'terraform init' for this configuration.
+# Terraform cannot create these resources automatically as part of backend initialisation.
+# Provision them manually or via a bootstrap script before first use.
+terraform {
+  backend "azurerm" {
+    resource_group_name   = "rg-uks-alz-tfstate-prod"
+    storage_account_name  = "alzprodstate"
+    container_name        = "tfstate"
+    key                   = "identity-prod.terraform.tfstate"
+  }
+}

--- a/project-a-zero-trust-landing-zone/terraform/identity/prod/main.tf
+++ b/project-a-zero-trust-landing-zone/terraform/identity/prod/main.tf
@@ -1,0 +1,77 @@
+# NOTE: All Conditional Access policies are currently defined in this main.tf file for simplicity.
+# As the number of policies grows, consider splitting each policy into its own .TF file
+# (e.g., conditional-access-require-mfa-admins.tf, conditional-access-block-legacy-auth.tf).
+# Place any new code for additional Identity services (e.g., groups, app registrations, role assignments)
+# in separate, logically-named .TF files for clarity and maintainability.
+resource "azuread_conditional_access_policy" "require_mfa_admins" {
+  display_name = "Require MFA for Admin Roles"
+  state        = "enabled"
+
+  conditions {
+    users {
+      included_roles = [
+        "62e90394-69f5-4237-9190-012177145e10" # Global Administrator
+        # Add more role IDs as needed
+      ]
+    }
+    applications {
+      included_applications = ["All"]
+    }
+    client_app_types = ["all"]
+  }
+
+  grant_controls {
+    operator = "or"
+    built_in_controls = ["mfa"]
+  }
+}
+
+####
+
+resource "azuread_conditional_access_policy" "block_legacy_auth" {
+  display_name = "Block Legacy Authentication for All Users"
+  state        = "enabled"
+
+  conditions {
+    users {
+      included_users = ["All"]
+    }
+    applications {
+      included_applications = ["All"]
+    }
+    client_app_types = [
+      "exchangeActiveSync",
+      "other"
+    ]
+  }
+
+  grant_controls {
+    operator = "or"
+    built_in_controls = ["block"]
+  }
+}
+
+####
+
+resource "azuread_conditional_access_policy" "require_mfa_all_users" {
+  display_name = "Require MFA for All Users"
+  state        = "enabled"
+
+  conditions {
+    users {
+      included_users = ["All"]
+      # Optionally exclude break-glass accounts by object ID
+      # to avoid being locked out if MFA is unavailable.
+      # excluded_users = ["<break-glass-user-object-id>"]
+    }
+    applications {
+      included_applications = ["All"]
+    }
+    client_app_types = ["all"]
+  }
+
+  grant_controls {
+    operator = "or"
+    built_in_controls = ["mfa"]
+  }
+}

--- a/project-a-zero-trust-landing-zone/terraform/identity/prod/provider.tf
+++ b/project-a-zero-trust-landing-zone/terraform/identity/prod/provider.tf
@@ -1,0 +1,29 @@
+# The "azuread" provider operates at the Microsoft Entra ID tenant level.
+# To deploy Conditional Access policies, the executing user or service principal (SPN)
+# must have the "Conditional Access Administrator" or "Global Administrator" role in Entra ID.
+# NOTE: "Conditional Access Administrator" should be the preferred choice for this purpose.
+# For pipelines, ensure the SPN is assigned one of these directory roles before deployment.
+# (Contributor or Owner roles in ARM/subscription are NOT sufficient.)
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.80" # Check latest available stable version.
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.50.0" # Check latest available stable version.
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  # Optionally specify subscription_id if needed:
+  # subscription_id = var.subscription_id
+}
+
+provider "azuread" {
+  # Optionally specify tenant_id if you want to be explicit:
+  # tenant_id = var.tenant_id
+}


### PR DESCRIPTION
Add initial Terraform code to `/identity/prod/` to manage a basic set of best practice / "must have" Conditional Access policies via the `azuread` provider.

Also add a supporting README.md file plus a placeholder README in `identity/nonprod`.

